### PR TITLE
Implement IEnumerable interface in ConsoleMenu.

### DIFF
--- a/ConsoleMenu/ConsoleMenu.cs
+++ b/ConsoleMenu/ConsoleMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -9,7 +10,7 @@ namespace ConsoleTools;
 /// <summary>
 /// A simple, highly customizable, DOS-like console menu.
 /// </summary>
-public class ConsoleMenu
+public class ConsoleMenu : IEnumerable
 {
   internal IConsole Console = new SystemConsole();
   private readonly MenuConfig config = new MenuConfig();
@@ -190,4 +191,11 @@ public class ConsoleMenu
         this.config,
         this.closeTrigger).Show();
   }
+
+  /// <summary>
+  /// Returns an enumeration of the current menu items.
+  /// See <see cref="Items"/>.
+  /// </summary>
+  /// <returns>An enumeration of the current menu items.</returns>
+  public IEnumerator GetEnumerator() => this.Items.GetEnumerator();
 }

--- a/ConsoleMenu/PublicAPI.Unshipped.txt
+++ b/ConsoleMenu/PublicAPI.Unshipped.txt
@@ -8,6 +8,7 @@ ConsoleTools.ConsoleMenu.ConsoleMenu() -> void
 ConsoleTools.ConsoleMenu.ConsoleMenu(string![]! args, int level) -> void
 ConsoleTools.ConsoleMenu.CurrentItem.get -> ConsoleTools.MenuItem!
 ConsoleTools.ConsoleMenu.CurrentItem.set -> void
+ConsoleTools.ConsoleMenu.GetEnumerator() -> System.Collections.IEnumerator!
 ConsoleTools.ConsoleMenu.Items.get -> System.Collections.Generic.IReadOnlyList<ConsoleTools.MenuItem!>!
 ConsoleTools.ConsoleMenu.Show() -> void
 ConsoleTools.MenuConfig


### PR DESCRIPTION
Implements the change suggested in #8:
`ConsoleMenu` now implements `IEnumerable`, allowing for the collection intialization syntax to be used when creating menus.